### PR TITLE
HJ-401 Fix Upload to Snowflake action

### DIFF
--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -14,6 +14,9 @@ on:
       - .github/workflows/snowflake_upload.yml
       - ethyca/scripts/snowflake_pipeline.py
 
+env:
+  DEFAULT_PYTHON_VERSION: "3.10.11"
+
 jobs:
   Upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: "pip"
 
       - name: Install Dependencies
         run: pip install -r ethyca/scripts/requirements.txt

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Install Build Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev
 
       - name: Install Python
         uses: actions/setup-python@v2

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -14,10 +14,6 @@ on:
       - .github/workflows/snowflake_upload.yml
       - ethyca/scripts/snowflake_pipeline.py
 
-  push:
-    branches:
-      - jade/fix_gh_action
-
 env:
   DEFAULT_PYTHON_VERSION: "3.10.11"
 
@@ -30,6 +26,11 @@ jobs:
       
       - name: Install Build Dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install Dependencies
         run: pip install -r ethyca/scripts/requirements.txt

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -10,10 +10,13 @@ on:
     # Run the workflow if it gets changed in a PR so it can be tested.
     branches:
       - main
-      - jade/fix_gh_action
     paths:
       - .github/workflows/snowflake_upload.yml
       - ethyca/scripts/snowflake_pipeline.py
+
+  push:
+    branches:
+      - jade/fix_gh_action
 
 env:
   DEFAULT_PYTHON_VERSION: "3.10.11"
@@ -24,6 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      
+      - name: Install Build Dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential
 
       - name: Install Dependencies
         run: pip install -r ethyca/scripts/requirements.txt

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -10,7 +10,7 @@ on:
     # Run the workflow if it gets changed in a PR so it can be tested.
     branches:
       - main
-      - 
+      - jade/fix_gh_action
     paths:
       - .github/workflows/snowflake_upload.yml
       - ethyca/scripts/snowflake_pipeline.py

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Install Build Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libffi-dev
 
       - name: Install Python
         uses: actions/setup-python@v2

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Install Build Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libffi-dev libssl1.1
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libffi-dev libssl3
 
       - name: Install Python
         uses: actions/setup-python@v2

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -23,9 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
-      - name: Install Build Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libffi-dev libssl3
 
       - name: Set Up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -10,6 +10,7 @@ on:
     # Run the workflow if it gets changed in a PR so it can be tested.
     branches:
       - main
+      - 
     paths:
       - .github/workflows/snowflake_upload.yml
       - ethyca/scripts/snowflake_pipeline.py

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Install Build Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libffi-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libffi-dev libssl1.1
 
       - name: Install Python
         uses: actions/setup-python@v2

--- a/.github/workflows/snowflake_upload.yml
+++ b/.github/workflows/snowflake_upload.yml
@@ -22,15 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Install Build Dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libffi-dev libssl3
 
-      - name: Install Python
-        uses: actions/setup-python@v2
+      - name: Set Up Python
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
 
       - name: Install Dependencies
         run: pip install -r ethyca/scripts/requirements.txt

--- a/ethyca/scripts/requirements.txt
+++ b/ethyca/scripts/requirements.txt
@@ -1,3 +1,3 @@
 numpy<2.0.0
 pandas==1.4.3
-snowflake-sqlalchemy==1.4.3
+snowflake-sqlalchemy==1.7.3


### PR DESCRIPTION
Github Action erroring with:

```bash
        × Building wheel for pyarrow (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [599 lines of output]
```
- Updated env with `DEFAULT_PYTHON_VERSION: "3.10.11"`
- Added `Set Up Python` job to set python version
- Updated the actions versions for `actions/checkout@v4` 

Started getting new error: 
```bash
Error:     raise LibraryNotFoundError('Error detecting the version of libcrypto')
oscrypto.errors.LibraryNotFoundError: Error detecting the version of libcrypto
Error: Process completed with exit code 1.
```
This is a [known issue](https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto) and can show up with most Snowflake connectors. 

- Updated to latest version of snowflake-sqlalchemy